### PR TITLE
Jpr quick fix for val

### DIFF
--- a/lib/burnside/convert-expr.cc
+++ b/lib/burnside/convert-expr.cc
@@ -117,12 +117,10 @@ class ExprLowering {
   }
 
   /// Generate a logical/boolean constant of `value`
-  M::Type getMLIRlogicalType() {
-    return M::IntegerType::get(1, builder.getContext());
-  }
   M::Value *genMLIRLogicalConstant(M::MLIRContext *context, bool value) {
-    auto attr{builder.getIntegerAttr(getMLIRlogicalType(), value ? 1 : 0)};
-    return builder.create<M::ConstantOp>(getLoc(), getMLIRlogicalType(), attr)
+    M::Type mlirLogicalType{getMLIRlogicalType(builder.getContext())};
+    auto attr{builder.getIntegerAttr(mlirLogicalType, value ? 1 : 0)};
+    return builder.create<M::ConstantOp>(getLoc(), mlirLogicalType, attr)
         .getResult();
   }
   template<int KIND>
@@ -406,7 +404,7 @@ class ExprLowering {
   template<int KIND> M::Value *genval(const Ev::Not<KIND> &op) {
     auto *context{builder.getContext()};
     auto mlirLogical{builder.create<fir::ConvertOp>(
-        getLoc(), getMLIRlogicalType(), genval(op.left()))};
+        getLoc(), getMLIRlogicalType(context), genval(op.left()))};
     auto i1One{genMLIRLogicalConstant(context, 1)};
     auto mlirRes{builder.create<M::XOrOp>(getLoc(), mlirLogical, i1One)};
     auto firTy{getFIRType(builder.getContext(), defaults, LogicalCat, KIND)};
@@ -427,9 +425,8 @@ class ExprLowering {
       result = createCompareOp<M::CmpIOp>(op, M::CmpIPredicate::ne);
       break;
     case Ev::LogicalOperator::Not:
-      // LogicalOperations are binary operations. Expr for Not is
-      // evaluate::Not<KIND>.
-      assert(false);
+      // lib/evaluate expression for .NOT. is evaluate::Not<KIND>.
+      assert(false && ".NOT. is not a binary operator");
       break;
     }
     if (!result) {

--- a/lib/burnside/convert-type.cc
+++ b/lib/burnside/convert-type.cc
@@ -388,3 +388,7 @@ M::Type Br::translateSymbolToFIRType(M::MLIRContext *context,
 M::Type Br::convertReal(M::MLIRContext *context, int kind) {
   return genFIRType<RealCat>(context, kind);
 }
+
+M::Type Br::getMLIRlogicalType(M::MLIRContext *context) {
+  return M::IntegerType::get(1, context);
+}

--- a/lib/burnside/convert-type.h
+++ b/lib/burnside/convert-type.h
@@ -107,7 +107,9 @@ mlir::Type translateSymbolToFIRType(mlir::MLIRContext *ctxt,
     common::IntrinsicTypeDefaultKinds const &defaults,
     const semantics::SymbolRef symbol);
 
-mlir::Type convertReal(mlir::MLIRContext *context, int KIND);
+mlir::Type convertReal(mlir::MLIRContext *ctxt, int KIND);
+
+mlir::Type getMLIRlogicalType(mlir::MLIRContext *ctxt);
 
 }  // burnside
 }  // Fortran


### PR DESCRIPTION
Val, I made a fake PR to show you the quick FIX; the first commit just define helper functions to get MLIR boolean type. The answer to your question are the two lines added in `genCondBranch`.

I went further and made `if (flag) n = n + 1` work, but it is also a quick and dirty way of doing it:

The real thing should probably fix something in flattening:
https://github.com/schweitzpgi/f18/blob/a7b15e6899bd686a90cdfc40d9b709de922e5f95/lib/burnside/flattened.cc#L405

`ActionOp{ec}` should probably be replaced by something that produces the `ActionOp` for the `parser::ActionStmt` inside the `parser::IfStmt` instead of putting the `parser::ActionStmt` above the `parser::IfStmt` there.

With my branch, the following code should lower correctly until LLVM now.
```
subroutine foo(flag, n)
  logical :: flag
  integer :: n
  if (flag.AND.n.LE.10) n = n +1
end subroutine
```
